### PR TITLE
auto-define-os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,6 @@ set(catkin_LIBRARIES
   ${catkin_LIBRARIES}
 )
 
-define_os()
-
 #########################################
 # Declare the service files to be built #
 #########################################


### PR DESCRIPTION
# What changed?

I updated the CMake Macro search_for_cereal to search_for_cereal_required in order to make sure this dependency is not missing.

# Merge after the following merge:

machines-in-motion/mpi_cmake_modules#2