### PR TITLE
Improve safety detection and control

### DIFF
--- a/include/dg_blmc_robots/dgm_solo12.hpp
+++ b/include/dg_blmc_robots/dgm_solo12.hpp
@@ -73,6 +73,12 @@ public:
         dg_blmc_robots::JointCalibration::Request& req,
         dg_blmc_robots::JointCalibration::Response& res);
 
+    /**
+     * @brief compute_safety_controls computes safety controls very fast in case
+     * the dynamic graph is taking to much computation time or has crashed.
+     */
+    void compute_safety_controls();
+
 private:
     /**
      * @brief Calibrate the robot joint position

--- a/python/dg_blmc_robots/solo/solo_base_bullet.py
+++ b/python/dg_blmc_robots/solo/solo_base_bullet.py
@@ -85,7 +85,7 @@ class SoloBaseRobot(Robot):
         self.fr_index = self.pin_robot.model.getFrameId('FR_ANKLE')
 
         # Initialize the device.
-        self.device = Device('bullet_quadruped')
+        self.device = Device(self.config.robot_name)
         self.device.initialize(self.config.yaml_path)
 
         # Create signals for the base.
@@ -112,7 +112,7 @@ class SoloBaseRobot(Robot):
 
         self.steps_ = 0
 
-        super(SoloBaseRobot, self).__init__('bullet_quadruped',
+        super(SoloBaseRobot, self).__init__(self.config.robot_name,
             self.device)
 
     def start_video_recording(self):

--- a/src/dgm_solo12.cpp
+++ b/src/dgm_solo12.cpp
@@ -50,37 +50,86 @@ void DGMSolo12::initialize_hardware_communication_process()
         params_["hardware_communication"], "serial_port", serial_port);
 
     solo_.initialize(network_id, serial_port);
-}
+  }
 
-bool DGMSolo12::is_in_safety_mode()
-{
-    static int counter = 0;
-    if (solo_.get_joint_velocities().cwiseAbs().maxCoeff() > 100000003.875)
+  bool DGMSolo12::is_in_safety_mode()
+  {
+    // Check for too fast velocity. Value estiamted from small jump.
+    if (solo_.get_joint_velocities().cwiseAbs().maxCoeff() > 60.) 
     {
-        printf(
-            "DGMSolo12: Going into safe mode as joint velocity exceeded "
-            "bound.\n");
-        was_in_safety_mode_ = true;
+      was_in_safety_mode_ = true;
+      static int counter = 0;
+      if (counter % 2000 == 0) {
+        printf("DGMSolo12: Going into safe mode as joint velocity exceeded bound.\n");
+      }
+      counter += 1;
+    }
+
+    // Check for joint limits.
+    Eigen::Array<double, 12, 1> lower_lim, upper_lim;
+    lower_lim << -1.5, -1.5, -3., -1.5, -1.5, -3,
+                 -1.5, -1.5, -3., -1.5, -1.5, -3;
+    upper_lim = -lower_lim;
+
+    if ((solo_.get_joint_positions().array() < lower_lim).any())
+    {
+      was_in_safety_mode_ = true;
+      static int counter = 0;
+      if (counter % 2000 == 0) {
+        printf("DGMSolo12: below joint limits.\n");
+      }
+      counter += 1;
+    }
+
+    if ((solo_.get_joint_positions().array() > upper_lim).any())
+    {
+      was_in_safety_mode_ = true;
+      static int counter = 0;
+      if (counter % 2000 == 0) {
+        printf("DGMSolo12: above joint limits.\n");
+      }
+      counter += 1;
     }
 
     if (was_in_safety_mode_ || DynamicGraphManager::is_in_safety_mode())
     {
-        was_in_safety_mode_ = true;
-        counter++;
-        if (counter % 2000 == 0)
-        {
-            printf("DGMSolo12: is_in_safety_mode.\n");
-        }
-        return true;
+      static int counter = 0;
+      was_in_safety_mode_ = true;
+      if (counter % 2000 == 0) {
+        printf("DGMSolo12: is_in_safety_mode.\n");
+      }
+      counter++;
     }
-    else
-    {
-        return false;
-    }
-}
+    return was_in_safety_mode_;
+  }
 
-void DGMSolo12::get_sensors_to_map(dynamic_graph_manager::VectorDGMap& map)
-{
+  void DGMSolo12::compute_safety_controls()
+  {
+    // Check if there is an error with the motors. If so, best we can do is
+    // to command zero torques.
+    dynamicgraph::Vector& map_motor_board_errors = sensors_map_.at("motor_board_errors");
+    for(size_t i=0 ; i<map_motor_board_errors.size() ; ++i)
+    {
+      // Check if there is an error. In that case, send zero torques.
+      if (map_motor_board_errors[i] != 0) {
+        for (auto ctrl = motor_controls_map_.begin();
+            ctrl != motor_controls_map_.end();
+            ++ctrl)
+        {
+            ctrl->second.fill(0.0);
+        }
+        return;
+      }
+    }
+
+    // The motors are fine.
+    // --> Run a D controller to damp the current motion.
+    motor_controls_map_.at("ctrl_joint_torques") =
+        -0.05 * sensors_map_.at("joint_velocities");
+  }
+
+  void DGMSolo12::get_sensors_to_map(dynamic_graph_manager::VectorDGMap& map)
+  {
     solo_.acquire_sensors();
 
     /**


### PR DESCRIPTION
This PR improves the safety measurements (`is_in_safety_mode`) and replaces the default safety controller by a custom one for DGM solo12.

In details, this PR:
- adds a more realistic lower value for the maximum joint velocity
- adds joint limits (upper and lower bound)
- adds check if the robot reports an error (motor board error)

In all cases a hint is printed every 2 seconds to the command line.

In addition, this PR implements a custom safety controller: If the robot is working proper (that is, no error's are detected) and the robot is supposed to go into safe mode, a D controller to damp the motion is applied.