### PR TITLE
Load the dgm_yaml files from the python install folders

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,11 +10,50 @@ set(robot_properties_package_names
     robot_properties_solo robot_properties_solo robot_properties_solo
     robot_properties_teststand)
 
+# get the python install dir
+function(get_python_resources_dir robot_family robot_name output)
+    set(PYTHON_VERSION "" CACHE STRING
+        "Specify specific Python version to use ('major.minor' or 'major')")
+    # if not specified otherwise use Python 3
+    if(NOT PYTHON_VERSION)
+        set(PYTHON_VERSION "3")
+    endif()
+
+    find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+    message(STATUS "Using PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
+
+    # avoid storing backslash in cached variable since CMake will interpret it as escape character
+    set(_python_code
+      "import robot_properties_${robot_family}.utils"
+      "import os"
+      "print(robot_properties_${robot_family}.utils.find_paths('${robot_name}')['resources'].replace(os.sep, '/'))"
+    )
+    execute_process(
+      COMMAND
+      "${PYTHON_EXECUTABLE}"
+      "-c"
+      "${_python_code}"
+      OUTPUT_VARIABLE _output
+      RESULT_VARIABLE _result
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT _result EQUAL 0)
+      message(FATAL_ERROR
+        "execute_process(${PYTHON_EXECUTABLE} -c '${_python_code}') returned "
+        "error code ${_result}")
+    endif()
+
+    set(${output} "${_output}" PARENT_SCOPE)
+endfunction()
+
+get_python_resources_dir("solo" "solo12" python_solo_resources)
+get_python_resources_dir("teststand" "teststand" python_teststand_resources)
+
 set(dynamic_graph_manager_yaml_files
-    dynamic_graph_manager/dgm_parameters_solo8.yaml
-    dynamic_graph_manager/dgm_parameters_solo8ti.yaml
-    dynamic_graph_manager/dgm_parameters_solo12.yaml
-    dynamic_graph_manager/dgm_parameters.yaml)
+    ${python_solo_resources}/dynamic_graph_manager/dgm_parameters_solo8.yaml
+    ${python_solo_resources}/dynamic_graph_manager/dgm_parameters_solo8ti.yaml
+    ${python_solo_resources}/dynamic_graph_manager/dgm_parameters_solo12.yaml
+    ${python_teststand_resources}/dynamic_graph_manager/dgm_parameters_teststand.yaml)
 
 #
 # Declare a simple macro to build the library.
@@ -31,7 +70,6 @@ macro(create_dgm_library robot_name)
            $<INSTALL_INTERFACE:include>)
   # Link the dependencies.
   ament_target_dependencies(${lib_name} mim_msgs)
-  target_link_libraries(${lib_name} ament_index_cpp::ament_index_cpp)
   target_link_libraries(${lib_name} blmc_drivers::blmc_drivers)
   target_link_libraries(${lib_name} blmc_robots::${robot_name})
   target_link_libraries(${lib_name} dynamic_graph_manager::dynamic_graph_manager)
@@ -59,8 +97,7 @@ macro(create_dgm_executable robot_name package_name resource_path)
   target_link_libraries(${executable_name} dgm_${robot_name})
   # Some compile definitions
   target_compile_definitions(
-    ${executable_name} PUBLIC ROBOT_PROPERTIES_PACKAGE_NAME="${package_name}"
-                              ROBOT_PROPERTIES_YAML_PATH="${resource_path}")
+    ${executable_name} PUBLIC ROBOT_PROPERTIES_YAML_PATH="${resource_path}")
 
   list(APPEND all_src_targets ${executable_name})
 endmacro(create_dgm_executable robot_name)

--- a/src/robot_executable/solo12.cpp
+++ b/src/robot_executable/solo12.cpp
@@ -7,15 +7,12 @@
  * This file uses the TestBench8Motors class in a small demo.
  */
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
 #include "dg_blmc_robots/dgm_solo12.hpp"
 
 int main(int, char* [])
 {
     // Get the dynamic_graph_manager config file.
-    std::string share_path = ament_index_cpp::get_package_share_directory(
-        ROBOT_PROPERTIES_PACKAGE_NAME);
-    std::string yaml_path = share_path + "/" + ROBOT_PROPERTIES_YAML_PATH;
+    std::string yaml_path = ROBOT_PROPERTIES_YAML_PATH;
     std::cout << "Loading paramters from " << yaml_path << std::endl;
     YAML::Node param = YAML::LoadFile(yaml_path);
 

--- a/src/robot_executable/solo8.cpp
+++ b/src/robot_executable/solo8.cpp
@@ -7,15 +7,12 @@
  * This file uses the TestBench8Motors class in a small demo.
  */
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
 #include "dg_blmc_robots/dgm_solo8.hpp"
 
 int main(int, char*[])
 {
     // Get the dynamic_graph_manager config file.
-    std::string share_path = ament_index_cpp::get_package_share_directory(
-        ROBOT_PROPERTIES_PACKAGE_NAME);
-    std::string yaml_path = share_path + "/" + ROBOT_PROPERTIES_YAML_PATH;
+    std::string yaml_path = ROBOT_PROPERTIES_YAML_PATH;
     std::cout << "Loading paramters from " << yaml_path << std::endl;
     YAML::Node param = YAML::LoadFile(yaml_path);
 

--- a/src/robot_executable/solo8ti.cpp
+++ b/src/robot_executable/solo8ti.cpp
@@ -7,15 +7,12 @@
  * This file uses the TestBench8Motors class in a small demo.
  */
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
 #include "dg_blmc_robots/dgm_solo8ti.hpp"
 
 int main(int, char*[])
 {
     // Get the dynamic_graph_manager config file.
-    std::string share_path = ament_index_cpp::get_package_share_directory(
-        ROBOT_PROPERTIES_PACKAGE_NAME);
-    std::string yaml_path = share_path + "/" + ROBOT_PROPERTIES_YAML_PATH;
+    std::string yaml_path = ROBOT_PROPERTIES_YAML_PATH;
     std::cout << "Loading paramters from " << yaml_path << std::endl;
     YAML::Node param = YAML::LoadFile(yaml_path);
 

--- a/src/robot_executable/teststand.cpp
+++ b/src/robot_executable/teststand.cpp
@@ -7,15 +7,12 @@
  * This file uses the TestBench8Motors class in a small demo.
  */
 
-#include "ament_index_cpp/get_package_share_directory.hpp"
 #include "dg_blmc_robots/dgm_teststand.hpp"
 
 int main(int, char*[])
 {
     // Get the dynamic_graph_manager config file.
-    std::string share_path = ament_index_cpp::get_package_share_directory(
-        ROBOT_PROPERTIES_PACKAGE_NAME);
-    std::string yaml_path = share_path + "/" + ROBOT_PROPERTIES_YAML_PATH;
+    std::string yaml_path = ROBOT_PROPERTIES_YAML_PATH;
     std::cout << "Loading paramters from " << yaml_path << std::endl;
     YAML::Node param = YAML::LoadFile(yaml_path);
 


### PR DESCRIPTION
After making the robot_properties_solo and robot_properties_teststand pip installable, the resources files are only copied under the python folder and no longer under the install resources folder. This change to the CMakeLists finds the path from the python install folder and uses it for the solo and teststand robots.