### PR TITLE
DGSoloSim: Step it only once per control cycle

### DIFF
--- a/python/dg_blmc_robots/solo/dg_bullet_solo.py
+++ b/python/dg_blmc_robots/solo/dg_bullet_solo.py
@@ -104,7 +104,7 @@ class DgBulletSoloBaseRobot(dynamic_graph_manager.robot.Robot):
             ]
         )
 
-    def run(self, steps=1):
+    def run(self, steps=1, sleep=False):
         """ Get input from Device, Step the simulation, feed the Device. """
 
         for _ in range(steps):
@@ -112,10 +112,8 @@ class DgBulletSoloBaseRobot(dynamic_graph_manager.robot.Robot):
             self.robot_bullet.send_joint_command(
                 np.matrix(self.device.ctrl_joint_torques.value).T
             )
-            pybullet.stepSimulation()
+            self.bullet_env.step(sleep=sleep)
             self._sim2signal()
-
-            self.bullet_env.step()
 
     def reset_state(self, q, dq):
         """Sets the bullet simulator and the signals to


### PR DESCRIPTION
The previous code called `pybullet.stepSimulation()` and the newer `self.bullet_env.step(sleep=sleep)`. This means the simulation was stepping twice per one control cycle.

This version of the code steps only once per control cycle (the way it was designed). Also, I make the simulation not sleep by default.