### PR TITLE
Rename blmc_robots package to solo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(mpi_cmake_modules REQUIRED)
 find_package(mim_msgs REQUIRED)
 # Depend on ament macros.
 find_package(blmc_drivers REQUIRED)
-find_package(blmc_robots REQUIRED)
+find_package(solo REQUIRED)
 find_package(dynamic_graph_manager REQUIRED)
 find_package(yaml_utils REQUIRED)
 find_package(PythonModules REQUIRED COMPONENTS robot_properties_solo)
@@ -43,7 +43,7 @@ ament_export_dependencies(
   mim_msgs
   ament_index_cpp
   blmc_drivers
-  blmc_robots
+  solo
   dynamic_graph_manager
   yaml_utils
   pinocchio_bullet

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 
     <name>dg_blmc_robots</name>
     <version>1.0.0</version>
-    
+
     <description>
         Dynamic Graph Manager wrapper around the blmc_robots drivers.
     </description>
@@ -24,11 +24,11 @@
     <!-- Run time dependencies. -->
     <depend>ament_index_cpp</depend>
     <depend>blmc_drivers</depend>
-    <depend>blmc_robots</depend>
+    <depend>solo</depend>
     <depend>dynamic_graph_manager</depend>
     <depend>yaml_utils</depend>
     <depend>mim_msgs</depend>
-    
+
     <!-- Python dependencies. -->
     <depend>robot_properties_solo</depend>
     <depend>robot_properties_teststand</depend>


### PR DESCRIPTION
The `blmc_robots` package got renamed to solo. Renaming all references.